### PR TITLE
Simplify bid simulator interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,1972 +3,642 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>고급 적격심사 입찰 분석 시스템</title>
+    <title>간편 입찰 전략 계산기</title>
     <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-        
-        body {
-            font-family: 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-            background: #f8fafc;
-            color: #334155;
-            line-height: 1.6;
-        }
-        
-        .header {
-            background: linear-gradient(135deg, #1e293b 0%, #334155 100%);
-            color: white;
-            padding: 20px 0;
-            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-        }
-        
-        .header-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            padding: 0 30px;
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-        }
-        
-        .logo {
-            display: flex;
-            align-items: center;
-            gap: 12px;
-        }
-        
-        .logo-icon {
-            width: 40px;
-            height: 40px;
-            background: #3b82f6;
-            border-radius: 8px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-weight: bold;
-            font-size: 18px;
-        }
-        
-        .system-title {
-            font-size: 24px;
-            font-weight: 600;
-            margin: 0;
-        }
-        
-        .version {
-            background: rgba(59, 130, 246, 0.2);
-            color: #93c5fd;
-            padding: 4px 12px;
-            border-radius: 20px;
-            font-size: 12px;
-            font-weight: 500;
-        }
-        
-        .container {
-            max-width: 1400px;
-            margin: 0 auto;
-            padding: 30px;
-        }
-        
-        .control-panel {
-            background: white;
-            border-radius: 12px;
-            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-            margin-bottom: 30px;
-            overflow: hidden;
-        }
-        
-        .panel-header {
-            background: #f1f5f9;
-            padding: 20px 30px;
-            border-bottom: 1px solid #e2e8f0;
-        }
-        
-        .panel-title {
-            font-size: 18px;
-            font-weight: 600;
-            color: #1e293b;
-            margin: 0;
-        }
-        
-        .panel-body {
-            padding: 30px;
-        }
-        
-        .input-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-            gap: 30px;
-        }
-        
-        .input-section {
-            background: #f8fafc;
-            border: 1px solid #e2e8f0;
-            border-radius: 8px;
-            padding: 24px;
-        }
-        
-        .section-title {
-            color: #475569;
-            font-size: 14px;
-            font-weight: 600;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-            margin-bottom: 20px;
-            display: flex;
-            align-items: center;
-            gap: 8px;
-        }
-        
-        .section-icon {
-            width: 16px;
-            height: 16px;
-            background: #3b82f6;
-            border-radius: 3px;
-        }
-        
-        .form-group {
-            margin-bottom: 20px;
-        }
-        
-        .form-group:last-child {
-            margin-bottom: 0;
-        }
-        
-        label {
-            display: block;
-            color: #374151;
-            font-weight: 500;
-            margin-bottom: 6px;
-            font-size: 13px;
-        }
-        
-        input, select {
-            width: 100%;
-            padding: 10px 14px;
-            border: 1px solid #d1d5db;
-            border-radius: 6px;
-            font-size: 14px;
-            background: white;
-            transition: border-color 0.2s, box-shadow 0.2s;
-        }
-        
-        input:focus, select:focus {
-            outline: none;
-            border-color: #3b82f6;
-            box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
-        }
-        
-        .input-group {
-            display: flex;
-            gap: 12px;
-            align-items: end;
-        }
-        
-        .input-group .form-group {
-            flex: 1;
-            margin-bottom: 0;
-        }
-        
-        .advanced-toggle {
-            background: #e2e8f0;
-            border: none;
-            padding: 8px 16px;
-            border-radius: 6px;
-            font-size: 12px;
-            color: #64748b;
-            cursor: pointer;
-            margin-top: 10px;
-        }
-        
-        .advanced-toggle:hover {
-            background: #cbd5e1;
-        }
-        
-        .advanced-section {
-            display: none;
-            margin-top: 20px;
-            padding-top: 20px;
-            border-top: 1px solid #e2e8f0;
-        }
-        
-        .action-bar {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            padding: 20px 0;
-            border-top: 1px solid #e2e8f0;
-            margin-top: 30px;
-        }
-        
-        .btn {
-            padding: 12px 24px;
-            border: none;
-            border-radius: 6px;
-            font-size: 14px;
-            font-weight: 600;
-            cursor: pointer;
-            transition: all 0.2s;
-            display: inline-flex;
-            align-items: center;
-            gap: 8px;
-        }
-        
-        .btn-primary {
-            background: #3b82f6;
-            color: white;
-        }
-        
-        .btn-primary:hover {
-            background: #2563eb;
-            box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
-        }
-        
-        .btn-secondary {
-            background: #6b7280;
-            color: white;
-        }
-        
-        .btn-secondary:hover {
-            background: #4b5563;
-        }
-        
-        .loading-overlay {
-            display: none;
-            position: fixed;
-            inset: 0;
-            background: rgba(15, 23, 42, 0.55);
-            backdrop-filter: blur(2px);
-            z-index: 2000;
-            align-items: center;
-            justify-content: center;
-            padding: 20px;
+        :root {
+            color-scheme: light;
+            --bg-color: #f6f8fc;
+            --text-color: #1f2933;
+            --subtle-text: #64748b;
+            --card-bg: #ffffff;
+            --primary: #2563eb;
+            --primary-dark: #1d4ed8;
+            --border: #e2e8f0;
         }
 
-        .loading-panel {
-            background: white;
-            border-radius: 16px;
-            box-shadow: 0 20px 40px rgba(15, 23, 42, 0.2);
-            width: 100%;
-            max-width: 520px;
-            padding: 60px 30px;
-            text-align: center;
-            position: relative;
-            overflow: hidden;
+        * {
+            box-sizing: border-box;
         }
-        
-        .loading-content {
-            position: relative;
-            z-index: 2;
-        }
-        
-        .loading-background {
-            position: absolute;
-            top: 0;
-            left: -100%;
-            width: 100%;
-            height: 100%;
-            background: linear-gradient(90deg, 
-                transparent 0%, 
-                rgba(59, 130, 246, 0.1) 20%, 
-                rgba(99, 102, 241, 0.15) 50%, 
-                rgba(59, 130, 246, 0.1) 80%, 
-                transparent 100%);
-            animation: loadingGradient 3s ease-in-out infinite;
-        }
-        
-        @keyframes loadingGradient {
-            0% { left: -100%; }
-            50% { left: 0%; }
-            100% { left: 100%; }
-        }
-        
-        .loading-title {
-            font-size: 20px;
-            font-weight: 600;
-            color: #1e293b;
-            margin-bottom: 15px;
-        }
-        
-        .loading-subtitle {
-            color: #64748b;
-            font-size: 14px;
-            margin-bottom: 30px;
-        }
-        
-        .loading-progress {
-            width: 100%;
-            max-width: 320px;
-            height: 4px;
-            background: #e2e8f0;
-            border-radius: 2px;
-            margin: 0 auto 20px;
-            overflow: hidden;
-        }
-        
-        .loading-bar {
-            height: 100%;
-            background: linear-gradient(90deg, #3b82f6, #6366f1);
-            border-radius: 2px;
-            width: 0%;
-            transition: width 0.3s ease;
-        }
-        
-        .loading-stats {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 30px;
-            margin-top: 40px;
-            max-width: 600px;
-            margin-left: auto;
-            margin-right: auto;
-        }
-        
-        .loading-stat {
-            text-align: center;
-        }
-        
-        .loading-stat-value {
-            font-size: 24px;
-            font-weight: 700;
-            color: #3b82f6;
-            display: block;
-        }
-        
-        .loading-stat-label {
-            font-size: 12px;
-            color: #64748b;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-            margin-top: 8px;
-        }
-        
-        .analysis-panel {
-            display: none;
-            grid-template-columns: repeat(2, 1fr);
-            gap: 30px;
-            margin-top: 30px;
-        }
-        
-        .metric-card {
-            background: white;
-            border-radius: 12px;
-            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-            overflow: hidden;
-        }
-        
-        .card-header {
-            background: #1e293b;
-            color: white;
-            padding: 16px 20px;
-            font-weight: 600;
-            font-size: 14px;
-        }
-        
-        .card-body {
-            padding: 24px 20px;
-        }
-        
-        .metric-row {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            padding: 12px 0;
-            border-bottom: 1px solid #f1f5f9;
-        }
-        
-        .metric-row:last-child {
-            border-bottom: none;
-            font-weight: 600;
-            color: #1e293b;
-        }
-        
-        .metric-label {
-            color: #64748b;
-            font-size: 13px;
-        }
-        
-        .metric-value {
-            font-weight: 600;
-            color: #1e293b;
-        }
-        
-        .chart-panel {
-            grid-column: 1 / -1;
-            background: white;
-            border-radius: 12px;
-            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-            overflow: hidden;
-        }
-        
-        .chart-header {
-            background: #f8fafc;
-            padding: 20px;
-            border-bottom: 1px solid #e2e8f0;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-        }
-        
-        .chart-title {
-            font-size: 16px;
-            font-weight: 600;
-            color: #1e293b;
+
+        body {
             margin: 0;
-        }
-        
-        .chart-controls {
-            display: flex;
-            gap: 10px;
-        }
-        
-        .chart-body {
-            padding: 30px;
-        }
-        
-        canvas {
-            max-width: 100%;
-            height: auto;
-        }
-        
-        .recommendation-panel {
-            grid-column: 1 / -1;
-            background: white;
-            border: 1px solid #e2e8f0;
-            border-left: 4px solid #10b981;
-            border-radius: 8px;
-            padding: 24px;
-        }
-        
-        .recommendation-header {
-            display: flex;
-            align-items: center;
-            gap: 12px;
-            margin-bottom: 16px;
-        }
-        
-        .recommendation-icon {
-            width: 24px;
-            height: 24px;
-            background: #10b981;
-            border-radius: 50%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            color: white;
-            font-weight: bold;
-            font-size: 12px;
-        }
-        
-        .recommendation-title {
-            font-size: 16px;
-            font-weight: 600;
-            color: #1e293b;
-            margin: 0;
-        }
-        
-        .recommendation-content {
-            color: #475569;
-            line-height: 1.7;
-        }
-        
-        .distribution-panel {
-            grid-column: 1 / -1;
-            background: white;
-            border-radius: 12px;
-            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-            overflow: hidden;
-        }
-        
-        .competitor-analysis {
-            grid-column: 1 / -1;
-            background: white;
-            border-radius: 12px;
-            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-            overflow: hidden;
-        }
-        
-        .heatmap-container {
-            padding: 20px;
-            text-align: center;
-        }
-        
-        .heatmap {
-            display: inline-grid;
-            grid-template-columns: repeat(10, 40px);
-            gap: 2px;
-            margin: 20px 0;
-        }
-        
-        .heatmap-cell {
-            width: 40px;
-            height: 40px;
-            border-radius: 4px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 10px;
-            font-weight: 600;
-            color: white;
-        }
-        
-        .risk-matrix {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 20px;
-            margin-top: 20px;
-        }
-        
-        .risk-item {
-            text-align: center;
-            padding: 20px;
-            border-radius: 8px;
-            background: #f8fafc;
-        }
-        
-        .risk-value {
-            font-size: 24px;
-            font-weight: 700;
-            margin-bottom: 8px;
-        }
-        
-        .risk-label {
-            font-size: 12px;
-            color: #64748b;
-            text-transform: uppercase;
-        }
-        
-        .status-bar {
-            background: #1e293b;
-            color: #94a3b8;
-            padding: 12px 30px;
-            font-size: 12px;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-        }
-        
-        .status-item {
-            display: flex;
-            align-items: center;
-            gap: 6px;
-        }
-        
-        .status-indicator {
-            width: 8px;
-            height: 8px;
-            background: #10b981;
-            border-radius: 50%;
-        }
-        
-        .warning-panel {
-            background: #fef3c7;
-            border: 1px solid #fbbf24;
-            border-radius: 8px;
-            padding: 16px;
-            margin-top: 30px;
-        }
-        
-        .warning-header {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            margin-bottom: 8px;
-        }
-        
-        .warning-icon {
-            color: #f59e0b;
-            font-weight: bold;
-        }
-        
-        .warning-title {
-            font-weight: 600;
-            color: #92400e;
-        }
-        
-        .warning-text {
-            color: #92400e;
-            font-size: 13px;
+            font-family: 'Pretendard', 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
+            background: var(--bg-color);
+            color: var(--text-color);
             line-height: 1.6;
         }
-        
-        @media (max-width: 1024px) {
-            .input-grid, .analysis-panel {
-                grid-template-columns: 1fr;
-            }
-            
-            .container {
-                padding: 20px;
-            }
-            
-            .header-content {
-                padding: 0 20px;
+
+        .app {
+            max-width: 760px;
+            margin: 0 auto;
+            padding: 32px 16px 48px;
+        }
+
+        .app-header {
+            text-align: center;
+            margin-bottom: 28px;
+        }
+
+        .app-header h1 {
+            font-size: 26px;
+            margin: 0 0 10px;
+            font-weight: 700;
+            color: #0f172a;
+        }
+
+        .app-header p {
+            margin: 0;
+            color: var(--subtle-text);
+            font-size: 15px;
+        }
+
+        .card {
+            background: var(--card-bg);
+            border-radius: 16px;
+            padding: 24px;
+            box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+        }
+
+        .input-card {
+            margin-bottom: 20px;
+        }
+
+        .field {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            margin-bottom: 16px;
+        }
+
+        .field label {
+            font-size: 14px;
+            font-weight: 600;
+            color: #334155;
+        }
+
+        .field input {
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            padding: 12px 14px;
+            font-size: 15px;
+            transition: border-color 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .field input:focus {
+            border-color: var(--primary);
+            box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.16);
+            outline: none;
+        }
+
+        .action-row {
+            display: flex;
+            gap: 12px;
+            margin-top: 8px;
+        }
+
+        .btn {
+            flex: 1;
+            border: none;
+            border-radius: 12px;
+            padding: 13px;
+            font-size: 15px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.2s ease;
+        }
+
+        .btn-primary {
+            background: var(--primary);
+            color: #ffffff;
+            box-shadow: 0 10px 24px rgba(37, 99, 235, 0.28);
+        }
+
+        .btn-primary:hover {
+            background: var(--primary-dark);
+            transform: translateY(-1px);
+        }
+
+        .btn-secondary {
+            background: #f1f5f9;
+            color: #1f2937;
+        }
+
+        .btn-secondary:hover {
+            background: #e2e8f0;
+        }
+
+        .loading-card {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 16px;
+            min-height: 170px;
+            text-align: center;
+            color: var(--subtle-text);
+            font-size: 14px;
+        }
+
+        .spinner {
+            width: 38px;
+            height: 38px;
+            border-radius: 50%;
+            border: 4px solid #dbeafe;
+            border-top-color: var(--primary);
+            animation: spin 1s linear infinite;
+        }
+
+        @keyframes spin {
+            to {
+                transform: rotate(360deg);
             }
         }
-        
+
+        .result-card {
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+        }
+
+        #resultSummary {
+            font-size: 15px;
+            color: #1f2937;
+            display: grid;
+            gap: 8px;
+        }
+
+        #resultSummary strong {
+            color: #0f172a;
+        }
+
+        #resultSummary .hint {
+            color: var(--subtle-text);
+            font-size: 14px;
+        }
+
+        .result-grid {
+            display: grid;
+            gap: 16px;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        }
+
+        .result-box {
+            background: #f8fafc;
+            border-radius: 14px;
+            padding: 18px;
+            border: 1px solid var(--border);
+        }
+
+        .result-box h3 {
+            margin: 0 0 10px;
+            font-size: 15px;
+            color: #1f2937;
+        }
+
+        .result-box ul {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            display: grid;
+            gap: 8px;
+            font-size: 14px;
+            color: #4b5563;
+        }
+
+        .result-box li strong {
+            color: #111827;
+        }
+
+        .probability-row {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            margin-bottom: 10px;
+            font-size: 14px;
+            color: #475569;
+        }
+
+        .probability-row:last-child {
+            margin-bottom: 0;
+        }
+
+        .probability-label {
+            width: 70px;
+            font-weight: 600;
+            color: #111827;
+        }
+
+        .probability-bar {
+            position: relative;
+            flex: 1;
+            height: 8px;
+            background: #e2e8f0;
+            border-radius: 999px;
+            overflow: hidden;
+        }
+
+        .probability-fill {
+            position: absolute;
+            inset: 0;
+            width: 0;
+            background: linear-gradient(90deg, #2563eb, #3b82f6);
+        }
+
+        .probability-value {
+            width: 58px;
+            text-align: right;
+            font-variant-numeric: tabular-nums;
+            color: #1f2937;
+        }
+
+        .note-card {
+            background: #f1f5f9;
+            border-radius: 14px;
+            padding: 18px;
+            border: 1px solid var(--border);
+            font-size: 14px;
+            color: #475569;
+        }
+
+        .note-card h3 {
+            margin: 0 0 6px;
+            font-size: 15px;
+            color: #1f2937;
+        }
+
+        .app-footer {
+            margin-top: 20px;
+            text-align: center;
+            font-size: 12px;
+            color: #94a3b8;
+        }
+
+        [hidden] {
+            display: none !important;
+        }
+
         @media (max-width: 640px) {
-            .header-content {
+            .action-row {
                 flex-direction: column;
-                gap: 15px;
-                text-align: center;
             }
-            
-            .action-bar {
-                flex-direction: column;
-                gap: 15px;
+
+            .btn {
+                width: 100%;
+            }
+
+            .app {
+                padding: 24px 14px 40px;
             }
         }
     </style>
 </head>
 <body>
-    <div class="header">
-        <div class="header-content">
-            <div class="logo">
-                <div class="logo-icon">ABS</div>
-                <h1 class="system-title">Advanced Bid Strategy Analytics</h1>
-            </div>
-            <div class="version">v3.0.0 Pro</div>
-        </div>
-    </div>
+    <div class="app">
+        <header class="app-header">
+            <h1>간편 입찰 전략 계산기</h1>
+            <p>핵심 수치만 입력하면 가장 유리한 투찰 구간을 바로 확인할 수 있습니다.</p>
+        </header>
 
-    <div class="container">
-        <div class="control-panel">
-            <div class="panel-header">
-                <h2 class="panel-title">고급 확률론적 입찰 분석 매개변수</h2>
+        <form id="simulationForm" class="card input-card">
+            <div class="field">
+                <label for="estimatedPrice">추정가격 (억원)</label>
+                <input type="number" id="estimatedPrice" name="estimatedPrice" min="1" step="0.1" value="100">
             </div>
-            <div class="panel-body">
-                <div class="input-grid">
-                    <div class="input-section">
-                        <div class="section-title">
-                            <div class="section-icon"></div>
-                            PROJECT PARAMETERS
-                        </div>
-                        <div class="form-group">
-                            <label>추정가격 (억원)</label>
-                            <input type="number" id="estimatedPrice" value="100" min="1" step="0.1">
-                        </div>
-                        <div class="form-group">
-                            <label>공사 분류</label>
-                            <select id="constructionType">
-                                <option value="building">건축공사</option>
-                                <option value="civil">토목공사</option>
-                                <option value="plant">플랜트공사</option>
-                                <option value="electric">전기공사</option>
-                                <option value="telecom">통신공사</option>
-                            </select>
-                        </div>
-                        <div class="input-group">
-                            <div class="form-group">
-                                <label>낙찰하한율 (%)</label>
-                                <input type="number" id="lowerLimit" value="87.745" min="80" max="95" step="0.001">
-                            </div>
-                            <div class="form-group">
-                                <label>예가 변동폭 (±%)</label>
-                                <input type="number" id="priceVariance" value="2.0" min="0.5" max="5.0" step="0.1">
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <div class="input-section">
-                        <div class="section-title">
-                            <div class="section-icon"></div>
-                            MARKET DYNAMICS & DISTRIBUTION
-                        </div>
-                        <div class="input-group">
-                            <div class="form-group">
-                                <label>참여업체 수</label>
-                                <input type="number" id="competitorCount" value="8" min="2" max="20">
-                            </div>
-                            <div class="form-group">
-                                <label>확률분포 모델</label>
-                                <select id="distributionModel">
-                                    <option value="normal">정규분포</option>
-                                    <option value="lognormal">로그정규분포</option>
-                                    <option value="beta">베타분포</option>
-                                    <option value="empirical">경험적분포</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="input-group">
-                            <div class="form-group">
-                                <label>평균 투찰률 (%)</label>
-                                <input type="number" id="avgBidRate" value="88.5" min="85" max="95" step="0.1">
-                            </div>
-                            <div class="form-group">
-                                <label>표준편차/분산</label>
-                                <input type="number" id="bidStdDev" value="0.8" min="0.1" max="3" step="0.1">
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label>경쟁사 상관계수</label>
-                            <input type="number" id="correlationCoeff" value="0.15" min="0" max="0.8" step="0.05">
-                        </div>
-                        <button class="advanced-toggle" onclick="toggleAdvanced('market')">고급 시장 분석 옵션 ▼</button>
-                        <div class="advanced-section" id="marketAdvanced">
-                            <div class="form-group">
-                                <label>시장 포지션 클러스터</label>
-                                <select id="marketCluster">
-                                    <option value="2">2개 그룹 (대형/중소)</option>
-                                    <option value="3">3개 그룹 (대형/중형/중소)</option>
-                                    <option value="4">4개 그룹 (세분화)</option>
-                                </select>
-                            </div>
-                            <div class="input-group">
-                                <div class="form-group">
-                                    <label>비대칭도 (Skewness)</label>
-                                    <input type="number" id="skewness" value="0.2" min="-2" max="2" step="0.1">
-                                </div>
-                                <div class="form-group">
-                                    <label>첨도 (Kurtosis)</label>
-                                    <input type="number" id="kurtosis" value="3.2" min="1" max="10" step="0.1">
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <div class="input-section">
-                        <div class="section-title">
-                            <div class="section-icon"></div>
-                            SIMULATION ENGINE
-                        </div>
-                        <div class="input-group">
-                            <div class="form-group">
-                                <label>복수예비가격 수</label>
-                                <input type="number" id="priceCount" value="15" min="5" max="25">
-                            </div>
-                            <div class="form-group">
-                                <label>추첨 수</label>
-                                <input type="number" id="drawCount" value="4" min="2" max="8">
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label>시뮬레이션 반복 횟수</label>
-                            <select id="simulationCount">
-                                <option value="10000">10K (빠름)</option>
-                                <option value="50000">50K (표준)</option>
-                                <option value="100000">100K (정밀)</option>
-                                <option value="500000">500K (고정밀)</option>
-                            </select>
-                        </div>
-                        <div class="form-group">
-                            <label>분석 해상도</label>
-                            <select id="analysisResolution">
-                                <option value="0.05">0.05% 간격 (표준)</option>
-                                <option value="0.01">0.01% 간격 (정밀)</option>
-                                <option value="0.001">0.001% 간격 (초정밀)</option>
-                            </select>
-                        </div>
-                        <button class="advanced-toggle" onclick="toggleAdvanced('simulation')">고급 엔진 설정 ▼</button>
-                        <div class="advanced-section" id="simulationAdvanced">
-                            <div class="form-group">
-                                <label>병렬 처리 워커</label>
-                                <select id="parallelWorkers">
-                                    <option value="1">단일 스레드</option>
-                                    <option value="4">4 워커</option>
-                                    <option value="8">8 워커</option>
-                                    <option value="16">16 워커 (최대)</option>
-                                </select>
-                            </div>
-                            <div class="form-group">
-                                <label>수렴 기준 (ε)</label>
-                                <input type="number" id="convergenceCriteria" value="0.001" min="0.0001" max="0.01" step="0.0001">
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <div class="input-section">
-                        <div class="section-title">
-                            <div class="section-icon"></div>
-                            ML-BASED ADJUSTMENTS
-                        </div>
-                        <div class="input-group">
-                            <div class="form-group">
-                                <label>발주처 가중치</label>
-                                <input type="number" id="agencyWeight" value="1.0" min="0.5" max="2.0" step="0.1">
-                            </div>
-                            <div class="form-group">
-                                <label>계절 보정계수</label>
-                                <select id="seasonAdjust">
-                                    <option value="0.95">Q1 (경쟁 심화)</option>
-                                    <option value="1.0">Q2 (평균)</option>
-                                    <option value="1.05">Q3 (경쟁 완화)</option>
-                                    <option value="0.98">Q4 (연말 효과)</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label>리스크-수익 모델</label>
-                            <select id="riskRewardModel">
-                                <option value="conservative">보수적 (수익률 × 0.7)</option>
-                                <option value="balanced">균형적 (수익률 × 1.0)</option>
-                                <option value="aggressive">공격적 (수익률 × 1.3)</option>
-                                <option value="sharpe">샤프지수 최적화</option>
-                            </select>
-                        </div>
-                        <button class="advanced-toggle" onclick="toggleAdvanced('ml')">머신러닝 고급 옵션 ▼</button>
-                        <div class="advanced-section" id="mlAdvanced">
-                            <div class="form-group">
-                                <label>과거 데이터 가중치 감쇠</label>
-                                <input type="number" id="timeDecay" value="0.95" min="0.8" max="1.0" step="0.01">
-                            </div>
-                            <div class="input-group">
-                                <div class="form-group">
-                                    <label>회귀 정규화 (λ)</label>
-                                    <input type="number" id="regularization" value="0.1" min="0" max="1" step="0.01">
-                                </div>
-                                <div class="form-group">
-                                    <label>부트스트랩 샘플</label>
-                                    <input type="number" id="bootstrapSamples" value="1000" min="100" max="10000" step="100">
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                
-                <div class="action-bar">
-                    <div class="status-item">
-                        <div class="status-indicator"></div>
-                        <span>Advanced Analytics Engine Ready</span>
-                    </div>
-                    <div style="display: flex; gap: 12px;">
-                        <button class="btn btn-secondary" onclick="resetParameters()">
-                            ↻ 초기화
-                        </button>
-                        <button class="btn btn-primary" onclick="executeAdvancedSimulation()">
-                            🚀 고급 분석 실행
-                        </button>
-                    </div>
-                </div>
+            <div class="field">
+                <label for="lowerLimit">낙찰하한율 (%)</label>
+                <input type="number" id="lowerLimit" name="lowerLimit" min="80" max="95" step="0.01" value="87.70">
             </div>
+            <div class="field">
+                <label for="avgBidRate">경쟁사 평균 투찰률 (%)</label>
+                <input type="number" id="avgBidRate" name="avgBidRate" min="80" max="99" step="0.05" value="88.50">
+            </div>
+            <div class="field">
+                <label for="competitorCount">참여업체 수</label>
+                <input type="number" id="competitorCount" name="competitorCount" min="2" max="30" step="1" value="8">
+            </div>
+            <div class="action-row">
+                <button type="submit" class="btn btn-primary">분석 실행</button>
+                <button type="button" id="resetButton" class="btn btn-secondary">초기화</button>
+            </div>
+        </form>
+
+        <div id="loadingIndicator" class="card loading-card" hidden>
+            <div class="spinner" aria-hidden="true"></div>
+            <p>빠른 시뮬레이션을 수행 중입니다...</p>
+            <small>대략 1초 내에 결과가 준비됩니다.</small>
         </div>
-        
-        <div class="analysis-panel" id="analysisPanel">
-            <div class="metric-card">
-                <div class="card-header">최적화 결과 (ML Enhanced)</div>
-                <div class="card-body" id="optimizationResults"></div>
-            </div>
-            
-            <div class="metric-card">
-                <div class="card-header">고급 통계 분석</div>
-                <div class="card-body" id="statisticalAnalysis"></div>
-            </div>
-            
-            <div class="chart-panel">
-                <div class="chart-header">
-                    <h3 class="chart-title">확률 분포 및 신뢰구간 분석</h3>
-                    <div class="chart-controls">
-                        <select id="chartType" onchange="updateAdvancedChart()">
-                            <option value="probability">확률 분포</option>
-                            <option value="confidence">신뢰구간</option>
-                            <option value="cumulative">누적 확률</option>
-                            <option value="risk">위험-수익 매트릭스</option>
-                        </select>
-                    </div>
+
+        <section id="resultSection" class="card result-card" hidden aria-live="polite">
+            <div id="resultSummary"></div>
+
+            <div class="result-grid">
+                <div class="result-box">
+                    <h3>핵심 지표</h3>
+                    <div id="strategyNotes"></div>
                 </div>
-                <div class="chart-body">
-                    <canvas id="analysisChart" width="1000" height="450"></canvas>
+                <div class="result-box">
+                    <h3>낙찰 확률 상위 구간</h3>
+                    <div id="probabilityList"></div>
                 </div>
             </div>
-            
-            <div class="distribution-panel">
-                <div class="chart-header">
-                    <h3 class="chart-title">경쟁사별 낙찰 확률 히트맵</h3>
-                </div>
-                <div class="heatmap-container">
-                    <div id="competitorHeatmap" class="heatmap"></div>
-                    <div class="risk-matrix" id="riskMatrix"></div>
-                </div>
+
+            <div class="note-card">
+                <h3>시장 해석</h3>
+                <p id="marketInsight"></p>
             </div>
-            
-            <div class="competitor-analysis">
-                <div class="chart-header">
-                    <h3 class="chart-title">상관관계 기반 경쟁 시나리오 분석</h3>
-                </div>
-                <div class="chart-body">
-                    <canvas id="competitorChart" width="1000" height="400"></canvas>
-                </div>
-            </div>
-            
-            <div class="recommendation-panel" id="recommendationPanel">
-                <div class="recommendation-header">
-                    <div class="recommendation-icon">🎯</div>
-                    <h3 class="recommendation-title">AI 기반 전략적 권고사항</h3>
-                </div>
-                <div class="recommendation-content" id="strategicRecommendation"></div>
-            </div>
-        </div>
-        
-        <div class="warning-panel">
-            <div class="warning-header">
-                <span class="warning-icon">⚠</span>
-                <span class="warning-title">고급 분석 시스템 고지사항</span>
-            </div>
-            <div class="warning-text">
-                본 시스템은 고급 확률론적 모델링, 기계학습 알고리즘, 그리고 다차원 통계 분석을 통한 의사결정 지원도구입니다. 
-                실제 입찰환경에서는 예측하지 못한 시장 변수들이 존재할 수 있으므로, 분석 결과는 전략 수립의 핵심 참고자료로 활용하되 
-                최종 투찰 결정은 종합적 리스크 평가와 함께 이루어져야 합니다.
-            </div>
-        </div>
-    </div>
-    
-    <div class="status-bar">
-        <div class="status-item">
-            <div class="status-indicator"></div>
-            <span>Advanced Monte Carlo Engine: Operational</span>
-        </div>
-        <div class="status-item">
-            <span>ML Models: Beta/LogNormal/Empirical Ready</span>
-        </div>
-        <div class="status-item">
-            <span>© 2025 Advanced Bid Strategy Systems Pro</span>
-        </div>
+        </section>
+
+        <footer class="app-footer">
+            ※ 본 계산기는 참고용 시뮬레이션 결과를 제공합니다. 실제 투찰 전 추가 검토가 필요합니다.
+        </footer>
     </div>
 
     <script>
-        let advancedSimulationData = null;
-        let currentChart = null;
-        let competitorCorrelations = null;
+        (() => {
+            const DEFAULTS = {
+                estimatedPrice: 100,
+                lowerLimit: 87.7,
+                avgBidRate: 88.5,
+                competitorCount: 8
+            };
 
-        function toggleAdvanced(section) {
-            const element = document.getElementById(section + 'Advanced');
-            const button = event.target;
-            
-            if (element.style.display === 'block') {
-                element.style.display = 'none';
-                button.innerHTML = button.innerHTML.replace('▲', '▼');
-            } else {
-                element.style.display = 'block';
-                button.innerHTML = button.innerHTML.replace('▼', '▲');
+            const ITERATIONS = 12000;
+            const RATE_STEP = 0.1;
+
+            const form = document.getElementById('simulationForm');
+            const loadingIndicator = document.getElementById('loadingIndicator');
+            const resultSection = document.getElementById('resultSection');
+            const resultSummary = document.getElementById('resultSummary');
+            const strategyNotes = document.getElementById('strategyNotes');
+            const probabilityList = document.getElementById('probabilityList');
+            const marketInsight = document.getElementById('marketInsight');
+            const resetButton = document.getElementById('resetButton');
+
+            form.addEventListener('submit', event => {
+                event.preventDefault();
+                runSimulation();
+            });
+
+            resetButton.addEventListener('click', () => {
+                form.reset();
+                runSimulation();
+            });
+
+            runSimulation();
+
+            function runSimulation() {
+                showLoading();
+
+                window.setTimeout(() => {
+                    const params = collectFormData();
+                    const results = simulateBids(params);
+                    hideLoading();
+                    displayResults(params, results);
+                }, 30);
             }
-        }
 
-        function executeAdvancedSimulation() {
-            document.getElementById('loadingPanel').style.display = 'flex';
-            document.getElementById('analysisPanel').style.display = 'none';
-            
-            const params = collectAdvancedParameters();
-            
-            let currentProgress = 0;
-            let currentIteration = 0;
-            let currentScenarios = 0;
-            
-            const updateLoadingStatus = (stage, progress, iteration, scenarios) => {
-                document.getElementById('currentStage').textContent = stage;
-                document.getElementById('loadingBar').style.width = progress + '%';
-                document.getElementById('iterationCount').textContent = iteration.toLocaleString();
-                document.getElementById('processedScenarios').textContent = scenarios.toLocaleString();
-            };
-            
-            // 고급 시뮬레이션 단계별 실행
-            setTimeout(() => {
-                updateLoadingStatus('분포 모델 초기화', 8, 0, 0);
-                
-                setTimeout(() => {
-                    updateLoadingStatus('상관관계 매트릭스 생성', 15, 0, 0);
-                    
-                    setTimeout(() => {
-                        updateLoadingStatus('베이지안 추론 엔진 구동', 25, 0, 0);
-                        
-                        setTimeout(() => {
-                            updateLoadingStatus('다차원 확률 계산', 45, params.simulationCount * 0.2, params.simulationCount * 20);
-                            
-                            setTimeout(() => {
-                                updateLoadingStatus('기계학습 최적화', 70, params.simulationCount * 0.6, params.simulationCount * 60);
-                                
-                                setTimeout(() => {
-                                    updateLoadingStatus('신뢰구간 추정', 85, params.simulationCount * 0.8, params.simulationCount * 80);
-                                    
-                                    setTimeout(() => {
-                                        updateLoadingStatus('위험-수익 분석', 95, params.simulationCount, params.simulationCount * 100);
-                                        
-                                        // 실제 고급 시뮬레이션 실행
-                                        const results = performAdvancedMonteCarloAnalysis(params);
-                                        advancedSimulationData = results;
-                                        
-                                        setTimeout(() => {
-                                            updateLoadingStatus('분석 완료', 100, params.simulationCount, params.simulationCount * 100);
-                                            
-                                            setTimeout(() => {
-                                                document.getElementById('loadingPanel').style.display = 'none';
-                                                
-                                                displayAdvancedResults(results);
-                                                renderAdvancedChart(results);
-                                                renderCompetitorHeatmap(results);
-                                                renderCompetitorCorrelation(results);
-                                                generateAdvancedRecommendation(results, params);
-                                                
-                                                document.getElementById('analysisPanel').style.display = 'grid';
-                                            }, 300);
-                                        }, 200);
-                                    }, 400);
-                                }, 500);
-                            }, 600);
-                        }, 400);
-                    }, 300);
-                }, 200);
-            }, 100);
-        }
+            function showLoading() {
+                loadingIndicator.hidden = false;
+                resultSection.hidden = true;
+            }
 
-        function collectAdvancedParameters() {
-            return {
-                estimatedPrice: parseFloat(document.getElementById('estimatedPrice').value),
-                lowerLimit: parseFloat(document.getElementById('lowerLimit').value),
-                priceVariance: parseFloat(document.getElementById('priceVariance').value),
-                competitorCount: parseInt(document.getElementById('competitorCount').value),
-                distributionModel: document.getElementById('distributionModel').value,
-                avgBidRate: parseFloat(document.getElementById('avgBidRate').value),
-                bidStdDev: parseFloat(document.getElementById('bidStdDev').value),
-                correlationCoeff: parseFloat(document.getElementById('correlationCoeff').value),
-                marketCluster: parseInt(document.getElementById('marketCluster').value),
-                skewness: parseFloat(document.getElementById('skewness').value),
-                kurtosis: parseFloat(document.getElementById('kurtosis').value),
-                priceCount: parseInt(document.getElementById('priceCount').value),
-                drawCount: parseInt(document.getElementById('drawCount').value),
-                simulationCount: parseInt(document.getElementById('simulationCount').value),
-                analysisResolution: parseFloat(document.getElementById('analysisResolution').value),
-                parallelWorkers: parseInt(document.getElementById('parallelWorkers').value),
-                convergenceCriteria: parseFloat(document.getElementById('convergenceCriteria').value),
-                agencyWeight: parseFloat(document.getElementById('agencyWeight').value),
-                seasonAdjust: parseFloat(document.getElementById('seasonAdjust').value),
-                riskRewardModel: document.getElementById('riskRewardModel').value,
-                timeDecay: parseFloat(document.getElementById('timeDecay').value),
-                regularization: parseFloat(document.getElementById('regularization').value),
-                bootstrapSamples: parseInt(document.getElementById('bootstrapSamples').value)
-            };
-        }
+            function hideLoading() {
+                loadingIndicator.hidden = true;
+            }
 
-        function performAdvancedMonteCarloAnalysis(params) {
-            const distributionGenerator = createDistributionGenerator(params);
-            const correlationMatrix = generateCorrelationMatrix(params.competitorCount, params.correlationCoeff, params.marketCluster);
-            competitorCorrelations = correlationMatrix;
+            function collectFormData() {
+                const estimatedPrice = sanitizeNumber(document.getElementById('estimatedPrice').value, DEFAULTS.estimatedPrice, 1, 10000);
+                let lowerLimit = sanitizeNumber(document.getElementById('lowerLimit').value, DEFAULTS.lowerLimit, 80, 95);
+                let avgBidRate = sanitizeNumber(document.getElementById('avgBidRate').value, DEFAULTS.avgBidRate, 80, 99);
+                let competitorCount = sanitizeNumber(document.getElementById('competitorCount').value, DEFAULTS.competitorCount, 2, 30);
 
-            const bidRateRange = [];
-            const probabilityDistribution = [];
-            const confidenceIntervals = [];
-            const riskMetrics = [];
+                avgBidRate = Math.max(lowerLimit + 0.1, avgBidRate);
+                competitorCount = Math.round(competitorCount);
 
-            const baseStep = params.analysisResolution;
-            for (let rate = params.lowerLimit; rate <= 94 + baseStep / 2; rate += baseStep) {
-                const normalizedRate = Math.round(rate * 1000000) / 1000000;
-                if (bidRateRange.length === 0 || normalizedRate > bidRateRange[bidRateRange.length - 1]) {
-                    bidRateRange.push(normalizedRate);
+                return { estimatedPrice, lowerLimit, avgBidRate, competitorCount };
+            }
+
+            function sanitizeNumber(value, fallback, min, max) {
+                const parsed = Number.parseFloat(value);
+                if (!Number.isFinite(parsed)) {
+                    return fallback;
                 }
+                return Math.min(max, Math.max(min, parsed));
             }
 
-            const totalRates = bidRateRange.length;
-            const totalSimulations = Math.max(1, params.simulationCount);
-            const winDiff = new Array(totalRates + 1).fill(0);
-            const competitorDiffs = Array.from({ length: params.competitorCount - 1 }, () => new Array(totalRates + 1).fill(0));
+            function simulateBids(params) {
+                const maxRate = Math.min(95, Math.max(params.lowerLimit + 1, params.avgBidRate + 3));
+                const rates = buildRateRange(params.lowerLimit, maxRate);
+                const wins = new Array(rates.length).fill(0);
+                const winningRates = [];
+                const competitorStd = calculateCompetitorSpread(params);
 
-            for (let iteration = 0; iteration < totalSimulations; iteration++) {
-                const competitorRates = generateCorrelatedBidRates(params, correlationMatrix, distributionGenerator);
+                for (let i = 0; i < ITERATIONS; i++) {
+                    const competitorRates = [];
+                    for (let c = 0; c < params.competitorCount; c++) {
+                        const sampled = clampNumber(generateNormalRandom(params.avgBidRate, competitorStd), params.lowerLimit, 99.5);
+                        competitorRates.push(sampled);
+                    }
 
-                let winningRate = Infinity;
-                let winningIndex = -1;
+                    let winningRate = Infinity;
+                    for (const rate of competitorRates) {
+                        if (rate >= params.lowerLimit && rate < winningRate) {
+                            winningRate = rate;
+                        }
+                    }
 
-                for (let c = 0; c < competitorRates.length; c++) {
-                    const rate = competitorRates[c];
-                    if (rate >= params.lowerLimit && rate < winningRate) {
-                        winningRate = rate;
-                        winningIndex = c;
+                    if (winningRate < Infinity) {
+                        winningRates.push(winningRate);
+                    }
+
+                    for (let idx = 0; idx < rates.length; idx++) {
+                        const myRate = rates[idx];
+                        if (myRate <= winningRate) {
+                            wins[idx]++;
+                        }
                     }
                 }
 
-                const thresholdIndex = winningRate === Infinity ? totalRates - 1 : findUpperBound(bidRateRange, winningRate);
-
-                if (thresholdIndex >= 0) {
-                    winDiff[0] += 1;
-                    winDiff[Math.min(totalRates, thresholdIndex + 1)] -= 1;
-                }
-
-                if (winningIndex >= 0) {
-                    const lossStart = Math.max(0, Math.min(totalRates, thresholdIndex + 1));
-                    if (lossStart < totalRates) {
-                        const compDiff = competitorDiffs[winningIndex];
-                        compDiff[lossStart] += 1;
-                        compDiff[totalRates] -= 1;
+                const probabilities = wins.map(count => count / ITERATIONS);
+                let bestIndex = 0;
+                for (let idx = 1; idx < probabilities.length; idx++) {
+                    if (probabilities[idx] > probabilities[bestIndex]) {
+                        bestIndex = idx;
                     }
                 }
-            }
 
-            let runningWin = 0;
-            let maxProbability = 0;
-            let optimalBidRate = bidRateRange[0] || params.lowerLimit;
-            let maxSharpeRatio = -Infinity;
-            let sharpeOptimalRate = bidRateRange[0] || params.lowerLimit;
+                const recommendedRate = rates[bestIndex];
+                const recommendedProbability = probabilities[bestIndex];
+                const confidence = calculateConfidenceInterval(recommendedProbability, ITERATIONS);
 
-            for (let i = 0; i < totalRates; i++) {
-                runningWin += winDiff[i];
-                const rate = bidRateRange[i];
-                const probability = runningWin / totalSimulations;
-                const meanProb = probability * 100;
-                const stdError = Math.sqrt(Math.max(probability * (1 - probability), 0) / totalSimulations);
-                const lowerCI = Math.max(0, (probability - 1.96 * stdError) * 100);
-                const upperCI = Math.min(100, (probability + 1.96 * stdError) * 100);
+                let averageWinningRate = null;
+                let winningRateStd = null;
+                let percentile10 = null;
+                let percentile90 = null;
 
-                probabilityDistribution.push(meanProb);
-                confidenceIntervals.push({ lower: lowerCI, upper: upperCI, mean: meanProb });
-
-                const expectedReturn = probability * (100 - rate);
-                const riskAdjustedReturn = calculateRiskAdjustedReturn(meanProb, rate, params.riskRewardModel);
-                const volatility = stdError * 100;
-                const sharpeRatio = volatility > 0 ? (expectedReturn - 2) / volatility : 0;
-
-                riskMetrics.push({
-                    expectedReturn,
-                    riskAdjustedReturn,
-                    volatility,
-                    sharpeRatio,
-                    varAtRisk: lowerCI,
-                    cvar: calculateConditionalTailRisk(probability, stdError)
-                });
-
-                if (meanProb > maxProbability) {
-                    maxProbability = meanProb;
-                    optimalBidRate = rate;
+                if (winningRates.length) {
+                    averageWinningRate = calculateMean(winningRates);
+                    winningRateStd = calculateStdDev(winningRates, averageWinningRate);
+                    const sorted = [...winningRates].sort((a, b) => a - b);
+                    percentile10 = pickPercentile(sorted, 0.1);
+                    percentile90 = pickPercentile(sorted, 0.9);
                 }
 
-                if (sharpeRatio > maxSharpeRatio) {
-                    maxSharpeRatio = sharpeRatio;
-                    sharpeOptimalRate = rate;
-                }
+                const order = rates.map((_, idx) => idx).sort((a, b) => probabilities[b] - probabilities[a]);
+                const topIndices = order.slice(0, Math.min(5, order.length));
+
+                return {
+                    rates,
+                    probabilities,
+                    recommendedRate,
+                    recommendedProbability,
+                    confidence,
+                    averageWinningRate,
+                    winningRateStd,
+                    percentile10,
+                    percentile90,
+                    topIndices,
+                    competitorStd
+                };
             }
 
-            const competitorAnalysis = competitorDiffs.map(diff => {
-                const competitorProbs = [];
-                let running = 0;
-                for (let i = 0; i < totalRates; i++) {
-                    running += diff[i];
-                    competitorProbs.push((running / totalSimulations) * 100);
-                }
-                return competitorProbs;
-            });
-
-            return {
-                bidRates: bidRateRange,
-                probabilities: probabilityDistribution,
-                confidenceIntervals: confidenceIntervals,
-                riskMetrics: riskMetrics,
-                competitorAnalysis: competitorAnalysis,
-                correlationMatrix: correlationMatrix,
-                optimalRate: optimalBidRate,
-                maxProbability: maxProbability,
-                sharpeOptimalRate: sharpeOptimalRate,
-                maxSharpeRatio: maxSharpeRatio,
-                avgProbability: probabilityDistribution.reduce((a, b) => a + b, 0) / probabilityDistribution.length,
-                distributionModel: params.distributionModel,
-                totalScenarios: totalSimulations
-            };
-        }
-
-        function createDistributionGenerator(params) {
-            switch (params.distributionModel) {
-                case 'lognormal':
-                    return (mean, stdDev) => {
-                        const mu = Math.log(mean * mean / Math.sqrt(stdDev * stdDev + mean * mean));
-                        const sigma = Math.sqrt(Math.log(1 + (stdDev * stdDev) / (mean * mean)));
-                        return Math.exp(generateNormalRandom(mu, sigma));
-                    };
-                case 'beta':
-                    return (mean, stdDev) => {
-                        const variance = stdDev * stdDev;
-                        const alpha = mean * (mean * (1 - mean) / variance - 1);
-                        const beta = (1 - mean) * (mean * (1 - mean) / variance - 1);
-                        return generateBetaRandom(alpha, beta) * 10 + 85; // 85-95% 범위로 스케일링
-                    };
-                case 'empirical':
-                    return (mean, stdDev) => {
-                        // 실제 과거 데이터 기반 분포 (시뮬레이션용 근사)
-                        const skewedNormal = generateSkewedNormal(mean, stdDev, params.skewness, params.kurtosis);
-                        return Math.max(85, Math.min(95, skewedNormal));
-                    };
-                default:
-                    return (mean, stdDev) => generateNormalRandom(mean, stdDev);
-            }
-        }
-
-        function generateCorrelationMatrix(size, baseCorr, clusters) {
-            const matrix = [];
-            for (let i = 0; i < size; i++) {
-                matrix[i] = [];
-                for (let j = 0; j < size; j++) {
-                    if (i === j) {
-                        matrix[i][j] = 1.0;
-                    } else {
-                        // 클러스터 내 높은 상관관계, 클러스터 간 낮은 상관관계
-                        const iCluster = Math.floor(i * clusters / size);
-                        const jCluster = Math.floor(j * clusters / size);
-                        const correlation = iCluster === jCluster ? baseCorr * 1.5 : baseCorr * 0.3;
-                        matrix[i][j] = Math.max(0, Math.min(0.8, correlation + (Math.random() - 0.5) * 0.1));
+            function buildRateRange(minRate, maxRate) {
+                const values = [];
+                for (let rate = minRate; rate <= maxRate + 1e-9; rate += RATE_STEP) {
+                    const rounded = Math.round(rate * 100) / 100;
+                    if (!values.length || Math.abs(rounded - values[values.length - 1]) > 1e-6) {
+                        values.push(rounded);
                     }
                 }
-            }
-            return matrix;
-        }
-
-        function generateCorrelatedBidRates(params, correlationMatrix, distributionGen) {
-            const size = params.competitorCount - 1;
-            const independentRandom = [];
-            
-            // 독립적인 랜덤 변수 생성
-            for (let i = 0; i < size; i++) {
-                independentRandom.push(generateStandardNormal());
-            }
-            
-            // Cholesky 분해를 통한 상관관계 적용 (간단한 근사)
-            const correlatedRates = [];
-            for (let i = 0; i < size; i++) {
-                let correlatedValue = independentRandom[i];
-                for (let j = 0; j < i; j++) {
-                    correlatedValue += correlationMatrix[i][j] * independentRandom[j];
+                if (values[values.length - 1] !== Math.round(maxRate * 100) / 100) {
+                    values.push(Math.round(maxRate * 100) / 100);
                 }
-                
-                // 분포 모델에 따른 변환
-                const baseRate = distributionGen(params.avgBidRate, params.bidStdDev);
-                const adjustedRate = baseRate + correlatedValue * params.bidStdDev * 0.5;
-                correlatedRates.push(Math.max(85, Math.min(95, adjustedRate)));
+                return values;
             }
-            
-            return correlatedRates;
-        }
 
-        function generateAdvancedBasePrices(params) {
-            const prices = [];
-            const baseVariance = params.estimatedPrice * 0.025; // 2.5% 기본 분산
-            
-            for (let i = 0; i < params.priceCount; i++) {
-                // 업체별 추정 편차와 시장 상황 반영
-                let price = params.estimatedPrice;
-                
-                // 정규분포 기본 + 시장 편향 추가
-                price += generateNormalRandom(0, baseVariance);
-                
-                // 계절적/시장 요인
-                price *= params.seasonAdjust * params.agencyWeight;
-                
-                // 시간 감쇠 효과 (최근 데이터 가중치)
-                const timeWeight = Math.pow(params.timeDecay, Math.random() * 12); // 12개월 감쇠
-                price *= (1 + (timeWeight - 1) * 0.1);
-                
-                prices.push(Math.max(0, price));
+            function calculateCompetitorSpread(params) {
+                const gap = Math.max(0.4, params.avgBidRate - params.lowerLimit);
+                const base = gap / 2.4;
+                const crowdFactor = (params.competitorCount - 2) * 0.05;
+                return Math.min(3, Math.max(0.4, base + crowdFactor));
             }
-            return prices;
-        }
 
-        function calculateRiskAdjustedReturn(probability, rate, model) {
-            const baseReturn = probability * (100 - rate) / 100;
-            
-            switch (model) {
-                case 'conservative':
-                    return baseReturn * 0.7;
-                case 'balanced':
-                    return baseReturn;
-                case 'aggressive':
-                    return baseReturn * 1.3;
-                case 'sharpe':
-                    // 샤프 지수 기반 최적화
-                    const riskFreeRate = 2.0;
-                    const volatility = Math.sqrt(probability * (100 - probability) / 100);
-                    return volatility > 0 ? (baseReturn - riskFreeRate) / volatility : baseReturn;
-                default:
-                    return baseReturn;
+            function calculateConfidenceInterval(probability, iterations) {
+                const error = Math.sqrt((probability * (1 - probability)) / iterations);
+                const low = Math.max(0, probability - 1.96 * error);
+                const high = Math.min(1, probability + 1.96 * error);
+                return { low, high };
             }
-        }
 
-        function generateStandardNormal() {
-            let u = 0, v = 0;
-            while(u === 0) u = Math.random();
-            while(v === 0) v = Math.random();
-            return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
-        }
-
-        function generateNormalRandom(mean, stdDev) {
-            return mean + generateStandardNormal() * stdDev;
-        }
-
-        function generateBetaRandom(alpha, beta) {
-            // Beta 분포 근사 (Gamma 분포 이용)
-            const x = Math.pow(Math.random(), 1/alpha);
-            const y = Math.pow(Math.random(), 1/beta);
-            return x / (x + y);
-        }
-
-        function generateSkewedNormal(mean, stdDev, skewness, kurtosis) {
-            let normal = generateNormalRandom(mean, stdDev);
-            
-            // 간단한 비대칭도 적용
-            if (skewness !== 0) {
-                normal += skewness * Math.pow(normal - mean, 3) / (6 * Math.pow(stdDev, 3));
+            function calculateMean(values) {
+                return values.reduce((sum, value) => sum + value, 0) / values.length;
             }
-            
-            // 첨도 조정
-            if (kurtosis !== 3) {
-                const excess = kurtosis - 3;
-                normal += excess * Math.pow(normal - mean, 4) / (24 * Math.pow(stdDev, 4));
+
+            function calculateStdDev(values, mean) {
+                if (values.length === 0) return 0;
+                const variance = values.reduce((sum, value) => sum + Math.pow(value - mean, 2), 0) / values.length;
+                return Math.sqrt(variance);
             }
-            
-            return normal;
-        }
 
-        function randomSample(array, count) {
-            const shuffled = [...array].sort(() => 0.5 - Math.random());
-            return shuffled.slice(0, count);
-        }
+            function pickPercentile(sortedValues, percentile) {
+                if (!sortedValues.length) return null;
+                const index = Math.floor((sortedValues.length - 1) * percentile);
+                return sortedValues[index];
+            }
 
-        function calculateMean(array) {
-            return array.reduce((a, b) => a + b, 0) / array.length;
-        }
+            function displayResults(params, results) {
+                const probabilityPercent = results.recommendedProbability * 100;
+                const confidenceLow = results.confidence.low * 100;
+                const confidenceHigh = results.confidence.high * 100;
+                const expectedAmount = params.estimatedPrice * (results.recommendedRate / 100);
 
-        function findUpperBound(array, target) {
-            let low = 0;
-            let high = array.length - 1;
-            let result = -1;
-            const epsilon = 1e-9;
+                resultSummary.innerHTML = `
+                    <p><strong>${results.recommendedRate.toFixed(2)}%</strong>로 투찰하면 예상 낙찰 확률은 <strong>${probabilityPercent.toFixed(1)}%</strong>입니다.</p>
+                    <p>예상 낙찰 금액은 약 <strong>${formatAmount(expectedAmount)}</strong>입니다.</p>
+                    <p class="hint">${buildStrategyHint(probabilityPercent)}</p>
+                `;
 
-            while (low <= high) {
-                const mid = Math.floor((low + high) / 2);
-                if (array[mid] <= target + epsilon) {
-                    result = mid;
-                    low = mid + 1;
-                } else {
-                    high = mid - 1;
+                const notes = [
+                    `낙찰 확률 95% 신뢰범위: <strong>${confidenceLow.toFixed(1)}%</strong> ~ <strong>${confidenceHigh.toFixed(1)}%</strong>`,
+                    `시뮬레이션 반복: <strong>${ITERATIONS.toLocaleString()}</strong>회`
+                ];
+
+                if (results.averageWinningRate !== null && results.winningRateStd !== null) {
+                    notes.splice(1, 0, `경쟁사 평균 낙찰률: <strong>${results.averageWinningRate.toFixed(2)}%</strong> (σ = ${results.winningRateStd.toFixed(2)}%)`);
                 }
+
+                strategyNotes.innerHTML = `<ul>${notes.map(note => `<li>${note}</li>`).join('')}</ul>`;
+
+                probabilityList.innerHTML = results.topIndices.map(idx => {
+                    const rate = results.rates[idx];
+                    const probability = results.probabilities[idx] * 100;
+                    const fillWidth = Math.max(3, Math.min(100, probability));
+                    return `
+                        <div class="probability-row">
+                            <div class="probability-label">${rate.toFixed(2)}%</div>
+                            <div class="probability-bar">
+                                <div class="probability-fill" style="width: ${fillWidth}%;"></div>
+                            </div>
+                            <div class="probability-value">${probability.toFixed(1)}%</div>
+                        </div>
+                    `;
+                }).join('');
+
+                marketInsight.textContent = buildMarketInsight(params, results);
+
+                resultSection.hidden = false;
             }
 
-            return result;
-        }
-
-        function calculateConditionalTailRisk(probability, stdError) {
-            if (stdError === 0) {
-                return probability * 100;
-            }
-
-            const z = -1.6448536269514729; // 5% 하위 구간
-            const tailProbability = 0.05;
-            const pdf = Math.exp(-0.5 * z * z) / Math.sqrt(2 * Math.PI);
-            const tailMean = probability - (stdError * pdf / tailProbability);
-
-            return Math.min(100, Math.max(0, tailMean * 100));
-        }
-
-        function displayAdvancedResults(results) {
-            // 최적화 결과 (ML Enhanced)
-            const sharpeMetric = results.riskMetrics.find((_, idx) => results.bidRates[idx] === results.sharpeOptimalRate);
-            const optimalMetric = results.riskMetrics.find((_, idx) => results.bidRates[idx] === results.optimalRate);
-            
-            document.getElementById('optimizationResults').innerHTML = `
-                <div class="metric-row">
-                    <span class="metric-label">최적 투찰률 (확률 최대)</span>
-                    <span class="metric-value">${results.optimalRate.toFixed(4)}%</span>
-                </div>
-                <div class="metric-row">
-                    <span class="metric-label">샤프 최적율 (위험조정)</span>
-                    <span class="metric-value">${results.sharpeOptimalRate.toFixed(4)}%</span>
-                </div>
-                <div class="metric-row">
-                    <span class="metric-label">최대 낙찰 확률</span>
-                    <span class="metric-value">${results.maxProbability.toFixed(3)}%</span>
-                </div>
-                <div class="metric-row">
-                    <span class="metric-label">위험조정 수익률</span>
-                    <span class="metric-value">${(optimalMetric?.riskAdjustedReturn || 0).toFixed(3)}%</span>
-                </div>
-                <div class="metric-row">
-                    <span class="metric-label">최적 샤프 지수</span>
-                    <span class="metric-value"><strong>${results.maxSharpeRatio.toFixed(4)}</strong></span>
-                </div>
-            `;
-
-            // 고급 통계 분석
-            const confidenceOptimal = results.confidenceIntervals.find((_, idx) => results.bidRates[idx] === results.optimalRate);
-            const avgVolatility = results.riskMetrics.reduce((sum, r) => sum + r.volatility, 0) / results.riskMetrics.length;
-            const highProbCount = results.probabilities.filter(p => p >= 15).length;
-            
-            document.getElementById('statisticalAnalysis').innerHTML = `
-                <div class="metric-row">
-                    <span class="metric-label">95% 신뢰구간</span>
-                    <span class="metric-value">${(confidenceOptimal?.lower || 0).toFixed(2)}% ~ ${(confidenceOptimal?.upper || 0).toFixed(2)}%</span>
-                </div>
-                <div class="metric-row">
-                    <span class="metric-label">평균 변동성 (σ)</span>
-                    <span class="metric-value">${avgVolatility.toFixed(4)}</span>
-                </div>
-                <div class="metric-row">
-                    <span class="metric-label">분포 모델</span>
-                    <span class="metric-value">${results.distributionModel.toUpperCase()}</span>
-                </div>
-                <div class="metric-row">
-                    <span class="metric-label">유효 구간 (≥15%)</span>
-                    <span class="metric-value">${highProbCount}개</span>
-                </div>
-                <div class="metric-row">
-                    <span class="metric-label">총 시나리오</span>
-                    <span class="metric-value"><strong>${results.totalScenarios.toLocaleString()}개</strong></span>
-                </div>
-            `;
-        }
-
-        function renderAdvancedChart(results) {
-            const canvas = document.getElementById('analysisChart');
-            const ctx = canvas.getContext('2d');
-            
-            ctx.clearRect(0, 0, canvas.width, canvas.height);
-            
-            const margin = { top: 50, right: 100, bottom: 80, left: 80 };
-            const chartWidth = canvas.width - margin.left - margin.right;
-            const chartHeight = canvas.height - margin.top - margin.bottom;
-            
-            // 고급 그리드 시스템
-            drawAdvancedGrid(ctx, margin, chartWidth, chartHeight);
-            
-            // 데이터 범위
-            const minRate = Math.min(...results.bidRates);
-            const maxRate = Math.max(...results.bidRates);
-            const maxProb = Math.max(...results.probabilities);
-            
-            // 확률 분포 곡선 그리기
-            ctx.strokeStyle = '#3b82f6';
-            ctx.lineWidth = 3;
-            ctx.beginPath();
-            
-            results.bidRates.forEach((rate, idx) => {
-                const x = margin.left + ((rate - minRate) / (maxRate - minRate)) * chartWidth;
-                const y = margin.top + chartHeight - (results.probabilities[idx] / maxProb) * chartHeight;
-                
-                if (idx === 0) ctx.moveTo(x, y);
-                else ctx.lineTo(x, y);
-            });
-            ctx.stroke();
-            
-            // 최적점들 표시
-            const optimalIndex = results.probabilities.findIndex((_, idx) => results.bidRates[idx] === results.optimalRate);
-            const sharpeIndex = results.probabilities.findIndex((_, idx) => results.bidRates[idx] === results.sharpeOptimalRate);
-            
-            // 확률 최적점
-            if (optimalIndex >= 0) {
-                const optimalX = margin.left + ((results.optimalRate - minRate) / (maxRate - minRate)) * chartWidth;
-                const optimalY = margin.top + chartHeight - (results.maxProbability / maxProb) * chartHeight;
-                
-                ctx.fillStyle = '#ef4444';
-                ctx.beginPath();
-                ctx.arc(optimalX, optimalY, 8, 0, 2 * Math.PI);
-                ctx.fill();
-                
-                ctx.fillStyle = '#1f2937';
-                ctx.font = '12px sans-serif';
-                ctx.textAlign = 'center';
-                ctx.fillText(`확률최적: ${results.optimalRate.toFixed(3)}%`, optimalX, optimalY - 20);
-            }
-            
-            // 샤프 최적점
-            if (sharpeIndex >= 0) {
-                const sharpeX = margin.left + ((results.sharpeOptimalRate - minRate) / (maxRate - minRate)) * chartWidth;
-                const sharpeY = margin.top + chartHeight - (results.probabilities[sharpeIndex] / maxProb) * chartHeight;
-                
-                ctx.fillStyle = '#10b981';
-                ctx.beginPath();
-                ctx.arc(sharpeX, sharpeY, 8, 0, 2 * Math.PI);
-                ctx.fill();
-                
-                ctx.fillStyle = '#1f2937';
-                ctx.font = '12px sans-serif';
-                ctx.textAlign = 'center';
-                ctx.fillText(`샤프최적: ${results.sharpeOptimalRate.toFixed(3)}%`, sharpeX, sharpeY - 20);
-            }
-            
-            drawChartLabels(ctx, margin, chartWidth, chartHeight, minRate, maxRate, maxProb);
-        }
-
-        function drawAdvancedGrid(ctx, margin, chartWidth, chartHeight) {
-            ctx.strokeStyle = '#f1f5f9';
-            ctx.lineWidth = 1;
-            
-            // 수직 그리드 (더 세밀하게)
-            for (let i = 0; i <= 20; i++) {
-                const x = margin.left + (chartWidth * i) / 20;
-                ctx.beginPath();
-                ctx.moveTo(x, margin.top);
-                ctx.lineTo(x, margin.top + chartHeight);
-                ctx.stroke();
-            }
-            
-            // 수평 그리드
-            for (let i = 0; i <= 10; i++) {
-                const y = margin.top + (chartHeight * i) / 10;
-                ctx.beginPath();
-                ctx.moveTo(margin.left, y);
-                ctx.lineTo(margin.left + chartWidth, y);
-                ctx.stroke();
-            }
-            
-            // 메인 축
-            ctx.strokeStyle = '#374151';
-            ctx.lineWidth = 2;
-            ctx.beginPath();
-            ctx.moveTo(margin.left, margin.top);
-            ctx.lineTo(margin.left, margin.top + chartHeight);
-            ctx.lineTo(margin.left + chartWidth, margin.top + chartHeight);
-            ctx.stroke();
-        }
-
-        function drawChartLabels(ctx, margin, chartWidth, chartHeight, minRate, maxRate, maxProb) {
-            ctx.fillStyle = '#6b7280';
-            ctx.font = '11px sans-serif';
-            ctx.textAlign = 'center';
-            
-            // X축 라벨 (더 세밀하게)
-            for (let i = 0; i <= 20; i++) {
-                const rate = minRate + (maxRate - minRate) * i / 20;
-                const x = margin.left + chartWidth * i / 20;
-                if (i % 4 === 0) { // 4개마다 표시
-                    ctx.fillText(rate.toFixed(2) + '%', x, margin.top + chartHeight + 25);
+            function buildStrategyHint(probability) {
+                if (probability >= 35) {
+                    return '낙찰 가능성이 높은 구간입니다. 다만 현장 조건을 다시 한번 확인하세요.';
                 }
-            }
-            
-            // Y축 라벨
-            ctx.textAlign = 'right';
-            for (let i = 0; i <= 10; i++) {
-                const prob = maxProb * i / 10;
-                const y = margin.top + chartHeight - chartHeight * i / 10;
-                ctx.fillText(prob.toFixed(1) + '%', margin.left - 15, y + 4);
-            }
-            
-            // 축 제목
-            ctx.fillStyle = '#374151';
-            ctx.font = '14px sans-serif';
-            ctx.textAlign = 'center';
-            ctx.fillText('투찰률 (%, 고정밀도)', margin.left + chartWidth / 2, margin.top + chartHeight + 55);
-            
-            ctx.save();
-            ctx.translate(25, margin.top + chartHeight / 2);
-            ctx.rotate(-Math.PI / 2);
-            ctx.fillText('낙찰 확률 (%, 95% 신뢰구간)', 0, 0);
-            ctx.restore();
-        }
-
-        function renderCompetitorHeatmap(results) {
-            const container = document.getElementById('competitorHeatmap');
-            container.innerHTML = '';
-            
-            const competitorCount = results.competitorAnalysis.length;
-            const rateCount = Math.min(results.bidRates.length, 100); // 최대 100개 셀
-            const step = Math.floor(results.bidRates.length / rateCount);
-            
-            container.style.gridTemplateColumns = `repeat(${rateCount}, 1fr)`;
-            
-            for (let comp = 0; comp < competitorCount; comp++) {
-                for (let rateIdx = 0; rateIdx < rateCount; rateIdx++) {
-                    const actualIdx = rateIdx * step;
-                    const probability = results.competitorAnalysis[comp][actualIdx] || 0;
-                    
-                    const cell = document.createElement('div');
-                    cell.className = 'heatmap-cell';
-                    
-                    // 색상 매핑 (확률에 따라)
-                    const intensity = Math.min(probability / 20, 1); // 20% 기준으로 정규화
-                    const red = Math.floor(255 * (1 - intensity));
-                    const blue = Math.floor(255 * intensity);
-                    cell.style.backgroundColor = `rgb(${red}, 100, ${blue})`;
-                    
-                    cell.textContent = probability.toFixed(1);
-                    cell.title = `경쟁사 ${comp + 1}, 투찰률: ${results.bidRates[actualIdx].toFixed(2)}%, 확률: ${probability.toFixed(1)}%`;
-                    
-                    container.appendChild(cell);
+                if (probability >= 20) {
+                    return '낙찰 가능성이 중간 수준입니다. 원가 및 리스크를 면밀히 점검하세요.';
                 }
+                return '낙찰 확률이 낮은 편이므로 가격 외 경쟁력 확보를 함께 고려하세요.';
             }
-            
-            // 위험 매트릭스 업데이트
-            updateRiskMatrix(results);
-        }
 
-        function updateRiskMatrix(results) {
-            const container = document.getElementById('riskMatrix');
-            const optimalMetric = results.riskMetrics.find((_, idx) => results.bidRates[idx] === results.optimalRate);
-            const sharpeMetric = results.riskMetrics.find((_, idx) => results.bidRates[idx] === results.sharpeOptimalRate);
-            
-            container.innerHTML = `
-                <div class="risk-item">
-                    <div class="risk-value" style="color: #ef4444;">${(optimalMetric?.varAtRisk || 0).toFixed(2)}%</div>
-                    <div class="risk-label">VaR (95%)</div>
-                </div>
-                <div class="risk-item">
-                    <div class="risk-value" style="color: #f59e0b;">${(optimalMetric?.cvar || 0).toFixed(2)}%</div>
-                    <div class="risk-label">CVaR</div>
-                </div>
-                <div class="risk-item">
-                    <div class="risk-value" style="color: #10b981;">${(sharpeMetric?.expectedReturn || 0).toFixed(3)}%</div>
-                    <div class="risk-label">Expected Return</div>
-                </div>
-            `;
-        }
+            function buildMarketInsight(params, results) {
+                const intensity = params.competitorCount <= 5
+                    ? '경쟁이 비교적 완만한 편입니다.'
+                    : params.competitorCount <= 9
+                        ? '경쟁이 보통 수준으로 예상됩니다.'
+                        : '경쟁이 다소 치열할 수 있습니다.';
 
-        function renderCompetitorCorrelation(results) {
-            const canvas = document.getElementById('competitorChart');
-            const ctx = canvas.getContext('2d');
-            
-            ctx.clearRect(0, 0, canvas.width, canvas.height);
-            
-            const margin = { top: 40, right: 60, bottom: 60, left: 60 };
-            const chartWidth = canvas.width - margin.left - margin.right;
-            const chartHeight = canvas.height - margin.top - margin.bottom;
-            
-            // 상관관계 매트릭스 시각화
-            const matrix = results.correlationMatrix;
-            const size = matrix.length;
-            const cellWidth = chartWidth / size;
-            const cellHeight = chartHeight / size;
-            
-            for (let i = 0; i < size; i++) {
-                for (let j = 0; j < size; j++) {
-                    const correlation = matrix[i][j];
-                    const x = margin.left + j * cellWidth;
-                    const y = margin.top + i * cellHeight;
-                    
-                    // 상관관계에 따른 색상 매핑
-                    const intensity = Math.abs(correlation);
-                    const hue = correlation > 0 ? 120 : 0; // 녹색(양의 상관) vs 빨간색(음의 상관)
-                    ctx.fillStyle = `hsla(${hue}, 70%, 50%, ${intensity})`;
-                    
-                    ctx.fillRect(x, y, cellWidth - 1, cellHeight - 1);
-                    
-                    // 상관계수 표시
-                    ctx.fillStyle = intensity > 0.5 ? 'white' : 'black';
-                    ctx.font = '10px sans-serif';
-                    ctx.textAlign = 'center';
-                    ctx.fillText(correlation.toFixed(2), x + cellWidth/2, y + cellHeight/2 + 3);
+                let distribution = '경쟁사 낙찰률 분포를 파악하기 어렵습니다.';
+                if (results.averageWinningRate !== null && results.winningRateStd !== null) {
+                    distribution = `평균 낙찰률은 ${results.averageWinningRate.toFixed(2)}%이고 표준편차는 ${results.winningRateStd.toFixed(2)}%입니다.`;
+                    if (results.percentile10 !== null && results.percentile90 !== null) {
+                        distribution += ` 주로 ${results.percentile10.toFixed(2)}% ~ ${results.percentile90.toFixed(2)}% 사이에서 낙찰이 이루어졌습니다.`;
+                    }
                 }
-            }
-            
-            // 축 라벨
-            ctx.fillStyle = '#374151';
-            ctx.font = '12px sans-serif';
-            ctx.textAlign = 'center';
-            
-            for (let i = 0; i < size; i++) {
-                const x = margin.left + i * cellWidth + cellWidth/2;
-                const y = margin.top + size * cellHeight + 20;
-                ctx.fillText(`C${i+1}`, x, y);
-                
-                const labelX = margin.left - 15;
-                const labelY = margin.top + i * cellHeight + cellHeight/2;
-                ctx.save();
-                ctx.translate(labelX, labelY);
-                ctx.rotate(-Math.PI / 2);
-                ctx.fillText(`경쟁사${i+1}`, 0, 0);
-                ctx.restore();
-            }
-        }
 
-        function updateAdvancedChart() {
-            if (!advancedSimulationData) return;
-            
-            const chartType = document.getElementById('chartType').value;
-            
-            switch (chartType) {
-                case 'probability':
-                    renderAdvancedChart(advancedSimulationData);
-                    break;
-                case 'confidence':
-                    renderConfidenceChart(advancedSimulationData);
-                    break;
-                case 'cumulative':
-                    renderCumulativeChart(advancedSimulationData);
-                    break;
-                case 'risk':
-                    renderRiskReturnChart(advancedSimulationData);
-                    break;
+                const margin = results.recommendedRate - params.lowerLimit;
+                const marginText = margin >= 0
+                    ? `권장 투찰률은 낙찰하한율보다 ${margin.toFixed(2)}%p 높은 ${results.recommendedRate.toFixed(2)}% 지점입니다.`
+                    : `권장 투찰률은 낙찰하한율보다 ${Math.abs(margin).toFixed(2)}%p 낮은 ${results.recommendedRate.toFixed(2)}% 지점입니다.`;
+
+                return `${intensity} ${distribution} ${marginText}`;
             }
-        }
 
-        function renderConfidenceChart(results) {
-            const canvas = document.getElementById('analysisChart');
-            const ctx = canvas.getContext('2d');
-            
-            ctx.clearRect(0, 0, canvas.width, canvas.height);
-            
-            const margin = { top: 50, right: 100, bottom: 80, left: 80 };
-            const chartWidth = canvas.width - margin.left - margin.right;
-            const chartHeight = canvas.height - margin.top - margin.bottom;
-            
-            drawAdvancedGrid(ctx, margin, chartWidth, chartHeight);
-            
-            const minRate = Math.min(...results.bidRates);
-            const maxRate = Math.max(...results.bidRates);
-            const maxCI = Math.max(...results.confidenceIntervals.map(ci => ci.upper));
-            
-            // 신뢰구간 영역 채우기
-            ctx.fillStyle = 'rgba(59, 130, 246, 0.15)';
-            ctx.beginPath();
-            
-            // 상한 그리기
-            results.bidRates.forEach((rate, idx) => {
-                const x = margin.left + ((rate - minRate) / (maxRate - minRate)) * chartWidth;
-                const y = margin.top + chartHeight - (results.confidenceIntervals[idx].upper / maxCI) * chartHeight;
-                if (idx === 0) ctx.moveTo(x, y);
-                else ctx.lineTo(x, y);
-            });
-            
-            // 하한 그리기 (역순)
-            for (let idx = results.bidRates.length - 1; idx >= 0; idx--) {
-                const rate = results.bidRates[idx];
-                const x = margin.left + ((rate - minRate) / (maxRate - minRate)) * chartWidth;
-                const y = margin.top + chartHeight - (results.confidenceIntervals[idx].lower / maxCI) * chartHeight;
-                ctx.lineTo(x, y);
+            function formatAmount(amount) {
+                return new Intl.NumberFormat('ko-KR', { minimumFractionDigits: 1, maximumFractionDigits: 1 }).format(amount) + '억 원';
             }
-            ctx.closePath();
-            ctx.fill();
-            
-            // 평균선
-            ctx.strokeStyle = '#3b82f6';
-            ctx.lineWidth = 2;
-            ctx.beginPath();
-            results.bidRates.forEach((rate, idx) => {
-                const x = margin.left + ((rate - minRate) / (maxRate - minRate)) * chartWidth;
-                const y = margin.top + chartHeight - (results.confidenceIntervals[idx].mean / maxCI) * chartHeight;
-                if (idx === 0) ctx.moveTo(x, y);
-                else ctx.lineTo(x, y);
-            });
-            ctx.stroke();
-            
-            drawChartLabels(ctx, margin, chartWidth, chartHeight, minRate, maxRate, maxCI);
-        }
 
-        function renderCumulativeChart(results) {
-            const canvas = document.getElementById('analysisChart');
-            const ctx = canvas.getContext('2d');
-            
-            ctx.clearRect(0, 0, canvas.width, canvas.height);
-            
-            const margin = { top: 50, right: 100, bottom: 80, left: 80 };
-            const chartWidth = canvas.width - margin.left - margin.right;
-            const chartHeight = canvas.height - margin.top - margin.bottom;
-            
-            drawAdvancedGrid(ctx, margin, chartWidth, chartHeight);
-            
-            const minRate = Math.min(...results.bidRates);
-            const maxRate = Math.max(...results.bidRates);
-            
-            // 누적 확률 계산
-            const cumulativeProbs = [];
-            let cumulative = 0;
-            results.probabilities.forEach(prob => {
-                cumulative += prob;
-                cumulativeProbs.push(cumulative);
-            });
-            const maxCumulative = Math.max(...cumulativeProbs);
-            
-            // 누적 확률 곡선
-            ctx.strokeStyle = '#8b5cf6';
-            ctx.lineWidth = 3;
-            ctx.beginPath();
-            
-            results.bidRates.forEach((rate, idx) => {
-                const x = margin.left + ((rate - minRate) / (maxRate - minRate)) * chartWidth;
-                const y = margin.top + chartHeight - (cumulativeProbs[idx] / maxCumulative) * chartHeight;
-                
-                if (idx === 0) ctx.moveTo(x, y);
-                else ctx.lineTo(x, y);
-            });
-            ctx.stroke();
-            
-            drawChartLabels(ctx, margin, chartWidth, chartHeight, minRate, maxRate, maxCumulative);
-        }
-
-        function renderRiskReturnChart(results) {
-            const canvas = document.getElementById('analysisChart');
-            const ctx = canvas.getContext('2d');
-            
-            ctx.clearRect(0, 0, canvas.width, canvas.height);
-            
-            const margin = { top: 50, right: 100, bottom: 80, left: 80 };
-            const chartWidth = canvas.width - margin.left - margin.right;
-            const chartHeight = canvas.height - margin.top - margin.bottom;
-            
-            drawAdvancedGrid(ctx, margin, chartWidth, chartHeight);
-            
-            const maxReturn = Math.max(...results.riskMetrics.map(r => r.expectedReturn));
-            const maxRisk = Math.max(...results.riskMetrics.map(r => r.volatility));
-            
-            // 위험-수익 산점도
-            results.riskMetrics.forEach((metric, idx) => {
-                const x = margin.left + (metric.volatility / maxRisk) * chartWidth;
-                const y = margin.top + chartHeight - (metric.expectedReturn / maxReturn) * chartHeight;
-                
-                // 샤프 비율에 따른 색상
-                const sharpeNorm = Math.max(0, Math.min(1, (metric.sharpeRatio + 2) / 4));
-                const hue = sharpeNorm * 120; // 빨강에서 녹색으로
-                
-                ctx.fillStyle = `hsl(${hue}, 70%, 50%)`;
-                ctx.beginPath();
-                ctx.arc(x, y, 4, 0, 2 * Math.PI);
-                ctx.fill();
-            });
-            
-            // 효율적 경계 표시
-            const efficientFrontier = results.riskMetrics
-                .filter(metric => metric.sharpeRatio > 0)
-                .sort((a, b) => a.volatility - b.volatility);
-            
-            if (efficientFrontier.length > 1) {
-                ctx.strokeStyle = '#ef4444';
-                ctx.lineWidth = 2;
-                ctx.setLineDash([5, 5]);
-                ctx.beginPath();
-                
-                efficientFrontier.forEach((metric, idx) => {
-                    const x = margin.left + (metric.volatility / maxRisk) * chartWidth;
-                    const y = margin.top + chartHeight - (metric.expectedReturn / maxReturn) * chartHeight;
-                    
-                    if (idx === 0) ctx.moveTo(x, y);
-                    else ctx.lineTo(x, y);
-                });
-                ctx.stroke();
-                ctx.setLineDash([]);
+            function clampNumber(value, min, max) {
+                return Math.min(max, Math.max(min, value));
             }
-            
-            // 라벨
-            ctx.fillStyle = '#374151';
-            ctx.font = '14px sans-serif';
-            ctx.textAlign = 'center';
-            ctx.fillText('위험도 (변동성)', margin.left + chartWidth / 2, canvas.height - 20);
-            
-            ctx.save();
-            ctx.translate(25, margin.top + chartHeight / 2);
-            ctx.rotate(-Math.PI / 2);
-            ctx.fillText('기대수익률', 0, 0);
-            ctx.restore();
-        }
 
-        function generateAdvancedRecommendation(results, params) {
-            let recommendation = '';
-            let riskProfile = '';
-            let strategy = '';
-            
-            const optimalMetric = results.riskMetrics.find((_, idx) => results.bidRates[idx] === results.optimalRate);
-            const sharpeMetric = results.riskMetrics.find((_, idx) => results.bidRates[idx] === results.sharpeOptimalRate);
-            const confidenceOptimal = results.confidenceIntervals.find((_, idx) => results.bidRates[idx] === results.optimalRate);
-            
-            // 위험도 프로파일 결정
-            if (optimalMetric?.volatility < 2) {
-                riskProfile = '안정적';
-            } else if (optimalMetric?.volatility < 5) {
-                riskProfile = '중위험';
-            } else {
-                riskProfile = '고위험';
+            function generateNormalRandom(mean, stdDev) {
+                let u1 = Math.random();
+                let u2 = Math.random();
+                u1 = u1 === 0 ? Number.MIN_VALUE : u1;
+                u2 = u2 === 0 ? Number.MIN_VALUE : u2;
+                const z0 = Math.sqrt(-2.0 * Math.log(u1)) * Math.cos(2.0 * Math.PI * u2);
+                return mean + z0 * stdDev;
             }
-            
-            // 전략 권고
-            if (results.maxProbability > 25 && results.maxSharpeRatio > 0.5) {
-                strategy = '적극적 수주 추진';
-                recommendation = `<strong>우수한 수주 기회</strong><br>`;
-                recommendation += `확률 최적점 <strong>${results.optimalRate.toFixed(4)}%</strong>에서 <strong>${results.maxProbability.toFixed(2)}%</strong>의 높은 낙찰 확률과 `;
-                recommendation += `샤프 비율 <strong>${results.maxSharpeRatio.toFixed(3)}</strong>을 달성할 수 있습니다.<br>`;
-                recommendation += `95% 신뢰구간: ${confidenceOptimal?.lower.toFixed(2)}% ~ ${confidenceOptimal?.upper.toFixed(2)}%`;
-            } else if (results.maxProbability > 15 && results.maxSharpeRatio > 0.2) {
-                strategy = '신중한 참여 고려';
-                recommendation = `<strong>균형적 접근 필요</strong><br>`;
-                recommendation += `위험조정 최적점 <strong>${results.sharpeOptimalRate.toFixed(4)}%</strong> (샤프: ${results.maxSharpeRatio.toFixed(3)})와 `;
-                recommendation += `확률 최적점 <strong>${results.optimalRate.toFixed(4)}%</strong> (확률: ${results.maxProbability.toFixed(2)}%) 사이에서 선택 필요.<br>`;
-                recommendation += `위험 프로필: ${riskProfile}, VaR: ${optimalMetric?.varAtRisk.toFixed(2)}%`;
-            } else {
-                strategy = '참여 재검토 권장';
-                recommendation = `<strong>고위험 시장 상황</strong><br>`;
-                recommendation += `최대 확률 ${results.maxProbability.toFixed(2)}%, 최적 샤프 비율 ${results.maxSharpeRatio.toFixed(3)}로 `;
-                recommendation += `수익성과 안정성이 모두 제한적입니다. 시장 조건 재분석 또는 전략적 철수를 고려하세요.`;
-            }
-            
-            recommendation += `<br><br><strong>고급 분석 결과:</strong><br>`;
-            recommendation += `• 분포 모델: ${params.distributionModel.toUpperCase()} (비대칭도: ${params.skewness}, 첨도: ${params.kurtosis})<br>`;
-            recommendation += `• 경쟁사 상관관계: ${params.correlationCoeff} (클러스터: ${params.marketCluster}개 그룹)<br>`;
-            recommendation += `• 예상 변동성: ${optimalMetric?.volatility.toFixed(4)} | CVaR: ${optimalMetric?.cvar.toFixed(2)}%<br>`;
-            recommendation += `• 권장 전략: ${strategy}`;
-            
-            document.getElementById('strategicRecommendation').innerHTML = recommendation;
-        }
-
-        function resetParameters() {
-            const inputs = {
-                'estimatedPrice': '100',
-                'lowerLimit': '87.745',
-                'priceVariance': '2.0',
-                'competitorCount': '8',
-                'distributionModel': 'normal',
-                'avgBidRate': '88.5',
-                'bidStdDev': '0.8',
-                'correlationCoeff': '0.15',
-                'marketCluster': '2',
-                'skewness': '0.2',
-                'kurtosis': '3.2',
-                'priceCount': '15',
-                'drawCount': '4',
-                'simulationCount': '50000',
-                'analysisResolution': '0.01',
-                'parallelWorkers': '4',
-                'convergenceCriteria': '0.001',
-                'agencyWeight': '1.0',
-                'seasonAdjust': '1.0',
-                'riskRewardModel': 'balanced',
-                'timeDecay': '0.95',
-                'regularization': '0.1',
-                'bootstrapSamples': '1000'
-            };
-            
-            Object.keys(inputs).forEach(id => {
-                const element = document.getElementById(id);
-                if (element) element.value = inputs[id];
-            });
-            
-            document.getElementById('analysisPanel').style.display = 'none';
-            document.getElementById('loadingPanel').style.display = 'none';
-            
-            // 고급 옵션 접기
-            ['marketAdvanced', 'simulationAdvanced', 'mlAdvanced'].forEach(id => {
-                const element = document.getElementById(id);
-                if (element) element.style.display = 'none';
-            });
-            
-            advancedSimulationData = null;
-        }
-
-        // 초기화 시 자동 실행
-        document.addEventListener('DOMContentLoaded', function() {
-            setTimeout(() => {
-                executeAdvancedSimulation();
-            }, 1000);
-        });
+        })();
     </script>
-    
-    <!-- 여기서 바로 로딩 패널이 와야 함 -->
-    <div class="loading-overlay" id="loadingPanel">
-        <div class="loading-panel">
-            <div class="loading-background"></div>
-            <div class="loading-content">
-                <div class="loading-title">고급 확률론적 시뮬레이션 실행 중</div>
-                <div class="loading-subtitle">다차원 분포 모델링 및 기계학습 기반 최적화를 수행하고 있습니다...</div>
-
-                <div class="loading-progress">
-                    <div class="loading-bar" id="loadingBar"></div>
-                </div>
-
-                <div class="loading-stats">
-                    <div class="loading-stat">
-                        <span class="loading-stat-value" id="iterationCount">0</span>
-                        <div class="loading-stat-label">Iterations</div>
-                    </div>
-                    <div class="loading-stat">
-                        <span class="loading-stat-value" id="processedScenarios">0</span>
-                        <div class="loading-stat-label">Scenarios</div>
-                    </div>
-                    <div class="loading-stat">
-                        <span class="loading-stat-value" id="currentStage">초기화</span>
-                        <div class="loading-stat-label">Current Stage</div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the dense dashboard with a minimal four-field form and compact results cards so the workflow is easy to follow
- add a lightweight Monte Carlo routine that surfaces a recommended bid rate, confidence interval, and top probability bands without extra controls
- refresh the styling with simple cards, loading indicator, and guidance text to keep the focus on key outcomes

## Testing
- not run (static HTML page)


------
https://chatgpt.com/codex/tasks/task_e_68d2881126c4832bb32caed801898302