### PR TITLE
Adjust bidding inputs to won and percent units

### DIFF
--- a/index.html
+++ b/index.html
@@ -349,13 +349,13 @@
 
         <form id="simulationForm" class="card input-card">
             <div class="field">
-                <label for="openPrice">예비가격 기초금액 (억원)</label>
-                <input type="number" id="openPrice" name="openPrice" min="1" step="0.000000001" value="100">
+                <label for="openPrice">예비가격 기초금액 (원)</label>
+                <input type="number" id="openPrice" name="openPrice" min="100000000" max="1000000000000" step="1" value="10000000000">
             </div>
             <div class="field">
-                <label for="aValue">a값 (억원)</label>
-                <input type="number" id="aValue" name="aValue" min="0" step="0.000000001" value="0">
-                <small class="field-hint">예비가격 기초금액에서 차감할 상수입니다. 계산은 차감된 금액으로 수행하며 결과에는 a값이 다시 더해집니다.</small>
+                <label for="aValue">a값 (원)</label>
+                <input type="number" id="aValue" name="aValue" min="0" step="1" value="0">
+                <small class="field-hint">예비가격 기초금액에서 차감할 상수입니다. 원 단위로 입력하며 계산은 차감된 금액으로 수행 후 결과에는 a값이 다시 더해집니다.</small>
             </div>
             <div class="field">
                 <label for="companyCount">참여 업체 수</label>
@@ -374,14 +374,14 @@
             </div>
             <div class="field-group" aria-live="polite">
                 <div class="field">
-                    <label for="baseRate">기준 투찰률 (소수)</label>
-                    <input type="number" id="baseRate" name="baseRate" min="0.3" max="1.2" step="0.00001" value="0.79995">
-                    <small class="field-hint">예비가격 기초금액에 곱해 기준가격을 계산할 때 사용하는 비율입니다.</small>
+                    <label for="baseRate">기준 투찰률 (%)</label>
+                    <input type="number" id="baseRate" name="baseRate" min="30" max="120" step="0.001" value="79.995">
+                    <small class="field-hint">예비가격 기초금액에 곱해 기준가격을 계산할 때 사용하는 비율입니다. 퍼센트(%) 단위로 입력하세요.</small>
                 </div>
                 <div class="field">
-                    <label for="rangeRatio">임계값 범위 비율 (소수)</label>
-                    <input type="number" id="rangeRatio" name="rangeRatio" min="0.001" max="0.5" step="0.0005" value="0.02">
-                    <small class="field-hint">기준가격 대비 상·하단 임계값 범위를 결정하는 ±비율입니다.</small>
+                    <label for="rangeRatio">임계값 범위 비율 (%)</label>
+                    <input type="number" id="rangeRatio" name="rangeRatio" min="0.1" max="50" step="0.05" value="2">
+                    <small class="field-hint">기준가격 대비 상·하단 임계값 범위를 결정하는 ±비율입니다. 퍼센트(%) 단위로 입력하세요.</small>
                 </div>
                 <div class="field">
                     <label for="positiveSampleSize">표본 크기 (+임계값 범위)</label>
@@ -445,8 +445,9 @@
 
     <script>
         (() => {
+            const ONE_EOK = 100000000;
             const DEFAULTS = {
-                openPrice: 100,
+                openPrice: 100 * ONE_EOK,
                 aValue: 0,
                 companyCount: 8,
                 distributionType: 'mixture',
@@ -476,6 +477,8 @@
                 }
             };
 
+            const MIN_OPEN_PRICE = 1 * ONE_EOK;
+            const MAX_OPEN_PRICE = 10000 * ONE_EOK;
             const CANDIDATE_GRID_POINTS = 121;
             const RATE_MIN = 50;
             const RATE_MAX = 120;
@@ -633,7 +636,7 @@
             }
 
             function collectFormData() {
-                const rawOpenPrice = sanitizeNumber(openPriceInput?.value, DEFAULTS.openPrice, 1, 10000);
+                const rawOpenPrice = sanitizeNumber(openPriceInput?.value, DEFAULTS.openPrice, MIN_OPEN_PRICE, MAX_OPEN_PRICE);
                 const defaultShift = Number.isFinite(DEFAULTS.aValue) ? DEFAULTS.aValue : 0;
                 let aValue = sanitizeNumber(aValueInput?.value, defaultShift, 0, rawOpenPrice);
                 const minEffectivePrice = 1e-9;
@@ -651,8 +654,20 @@
                     distributionType = DEFAULTS.distributionType;
                 }
                 const distributionParams = { ...(DEFAULTS.distributionParams[distributionType] ?? {}) };
-                const baseRate = sanitizeNumber(baseRateInput.value, DEFAULTS.calculation.baseRate, 0.3, 1.2);
-                const rangeRatio = sanitizeNumber(rangeRatioInput.value, DEFAULTS.calculation.rangeRatio, 0.001, 0.5);
+                const baseRatePercent = sanitizeNumber(
+                    baseRateInput.value,
+                    DEFAULTS.calculation.baseRate * 100,
+                    30,
+                    120
+                );
+                const baseRate = baseRatePercent / 100;
+                const rangeRatioPercent = sanitizeNumber(
+                    rangeRatioInput.value,
+                    DEFAULTS.calculation.rangeRatio * 100,
+                    0.1,
+                    50
+                );
+                const rangeRatio = rangeRatioPercent / 100;
                 let positiveSampleSize = sanitizeInteger(
                     positiveSampleSizeInput.value,
                     DEFAULTS.calculation.positiveSampleSize,
@@ -1857,14 +1872,15 @@
             }
 
             function formatPriceTick(value) {
-                if (!Number.isFinite(value)) {
+                const valueInEok = value / ONE_EOK;
+                if (!Number.isFinite(valueInEok)) {
                     return '';
                 }
-                const digits = value >= 100 ? 1 : 2;
+                const digits = valueInEok >= 100 ? 1 : 2;
                 return `${new Intl.NumberFormat('ko-KR', {
                     minimumFractionDigits: digits,
                     maximumFractionDigits: digits
-                }).format(value)}억`;
+                }).format(valueInEok)}억`;
             }
 
             function buildWinRateChartSummary(params, results) {
@@ -1984,7 +2000,11 @@
             }
 
             function formatAmount(amount) {
-                return new Intl.NumberFormat('ko-KR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(amount) + '억 원';
+                const amountInEok = amount / ONE_EOK;
+                if (!Number.isFinite(amountInEok)) {
+                    return '0억 원';
+                }
+                return new Intl.NumberFormat('ko-KR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(amountInEok) + '억 원';
             }
         })();
     </script>


### PR DESCRIPTION
## Summary
- update key form fields to capture 예비가격·a값 in 원 and 투찰률·임계값 비율 in percent with revised helper text
- add won-based defaults and bounds plus percent-to-decimal conversion so simulations continue to run correctly
- convert chart/amount formatting to handle 원 inputs while keeping outputs readable in 억 원

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d3e3a6ff80832bbedb239f0ad291df