### PR TITLE
Fix undefined threshold pass probability reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -959,6 +959,7 @@
 
                     const thresholdUpper = Math.min(price, high);
                     const thresholdShare = averageCdf(thresholdUpper, low, high, basePrice, pickSize, posN, negN);
+                    const thresholdPassProbability = thresholdShare;
 
                     const competitorShareBelow = (otherCompanyCount > 0 && distribution && typeof distribution.cdf === 'function')
                         ? clamp01(distribution.cdf(price))


### PR DESCRIPTION
## Summary
- ensure `thresholdPassProbability` is initialized during bid analysis to avoid runtime reference errors
- reuse the computed threshold share when competitor distribution data is unavailable

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d4be2dfadc832b972e073035cc78f9