### PR TITLE
Trim chart bids after cutoff

### DIFF
--- a/index.html
+++ b/index.html
@@ -1879,12 +1879,26 @@
                 const shift = getAmountShift(params);
                 const xValues = bids.map(bid => bid.price + shift);
                 const yValues = bids.map(bid => bid.probability);
-                const minX = Math.min(...xValues);
+
+                let cutoffIndex = bids.length - 1;
+                for (let i = bids.length - 1; i >= 1; i--) {
+                    if (Math.abs(yValues[i] - yValues[i - 1]) > 1e-6) {
+                        cutoffIndex = i;
+                        break;
+                    }
+                }
+                const extra = Math.ceil((bids.length - cutoffIndex) * 0.1);
+                const finalIndex = Math.min(bids.length - 1, cutoffIndex + extra);
+                const trimmedBids = bids.slice(0, finalIndex + 1);
+                const trimmedXValues = xValues.slice(0, finalIndex + 1);
+                const trimmedYValues = yValues.slice(0, finalIndex + 1);
+
+                const minX = Math.min(...trimmedXValues);
                 const openPriceReference = Number.isFinite(params?.nominalOpenPrice)
                     ? params.nominalOpenPrice
                     : params.openPrice + shift;
-                const maxX = Math.max(...xValues, openPriceReference);
-                const maxProbability = Math.max(...yValues);
+                const maxX = Math.max(...trimmedXValues, openPriceReference);
+                const maxProbability = Math.max(...trimmedYValues);
                 const xRange = Math.max(maxX - minX, 1e-9);
                 const yMax = computeNiceProbabilityCeiling(maxProbability);
                 const chartWidth = Math.max(width - padding.left - padding.right, 10);
@@ -1948,17 +1962,17 @@
                 ctx.stroke();
 
                 ctx.beginPath();
-                ctx.moveTo(scaleX(bids[0].price + shift), height - padding.bottom);
-                for (let idx = 0; idx < bids.length; idx++) {
-                    const bid = bids[idx];
+                ctx.moveTo(scaleX(trimmedBids[0].price + shift), height - padding.bottom);
+                for (let idx = 0; idx < trimmedBids.length; idx++) {
+                    const bid = trimmedBids[idx];
                     ctx.lineTo(scaleX(bid.price + shift), scaleY(bid.probability));
                 }
                 // 마지막 확률이 0보다 크다면, 그 다음에 X축과 수직으로 닫기
-                const lastBid = bids[bids.length - 1];
+                const lastBid = trimmedBids[trimmedBids.length - 1];
                 if (lastBid.probability > 0) {
                     ctx.lineTo(scaleX(lastBid.price + shift), height - padding.bottom);
                 }
-                ctx.lineTo(scaleX(bids[0].price + shift), height - padding.bottom);
+                ctx.lineTo(scaleX(trimmedBids[0].price + shift), height - padding.bottom);
                 ctx.closePath();
 
                 const gradient = ctx.createLinearGradient(0, padding.top, 0, height - padding.bottom);
@@ -1968,8 +1982,8 @@
                 ctx.fill();
 
                 ctx.beginPath();
-                for (let idx = 0; idx < bids.length; idx++) {
-                    const bid = bids[idx];
+                for (let idx = 0; idx < trimmedBids.length; idx++) {
+                    const bid = trimmedBids[idx];
                     const x = scaleX(bid.price + shift);
                     const y = scaleY(bid.probability);
                     if (idx === 0) {
@@ -1982,8 +1996,8 @@
                 ctx.lineWidth = 2;
                 ctx.stroke();
 
-                if (Number.isInteger(results.bestIndex) && results.bestIndex >= 0 && results.bestIndex < bids.length) {
-                    const bestBid = bids[results.bestIndex];
+                if (Number.isInteger(results.bestIndex) && results.bestIndex >= 0 && results.bestIndex < trimmedBids.length) {
+                    const bestBid = trimmedBids[results.bestIndex];
                     const x = scaleX(bestBid.price + shift);
                     const y = scaleY(bestBid.probability);
                     ctx.fillStyle = '#1d4ed8';


### PR DESCRIPTION
## Summary
- add cutoff detection to remove flat trailing bids before rendering the win-rate chart
- update chart drawing to use the trimmed bid list and protect the highlighted point lookup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4d3774720832bb0c21b450df5e29a