### PR TITLE
Adjust rival fail probability near threshold

### DIFF
--- a/index.html
+++ b/index.html
@@ -1301,6 +1301,28 @@
                     ? clamp01(1 - distribution.cdf(price))
                     : 0;
 
+                if (hasDistribution) {
+                    const competitorAtOrBelowPrice = clamp01(distribution.cdf(price));
+                    competitorShareBelow = Math.min(
+                        competitorShareBelow,
+                        competitorAtOrBelowPrice
+                    );
+                    const competitorSuccessProbability = Math.max(
+                        0,
+                        competitorAtOrBelowPrice - competitorShareBelow
+                    );
+                    const singleCompetitorFailProbability = clamp01(
+                        1 - competitorSuccessProbability
+                    );
+
+                    return {
+                        thresholdPassProbability,
+                        competitorShareBelow,
+                        bidsAboveUsProbability,
+                        singleCompetitorFailProbability
+                    };
+                }
+
                 const singleCompetitorFailProbability = clamp01(
                     competitorShareBelow + bidsAboveUsProbability
                 );


### PR DESCRIPTION
## Summary
- clamp the rival share below our price to the competitor CDF
- compute competitor failure probability from success probability when a distribution is available, keeping the existing fallback logic

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6822c417c832bb4f39f4dd936bcdc